### PR TITLE
APT repo key_id should be 40 chars

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,7 +260,7 @@ class elasticsearch(
   $java_package          = undef,
   $manage_repo           = false,
   $repo_version          = undef,
-  $repo_key_id           = 'D88E42B4',
+  $repo_key_id           = '46095ACC8548582C1A2699A9D27D666CD88E42B4',
   $repo_key_source       = 'http://packages.elastic.co/GPG-KEY-elasticsearch',
   $repo_proxy            = undef,
   $logging_file          = undef,


### PR DESCRIPTION
As part of your pull request, please review the following tasks:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass

To prevent

```
Warning: /Apt_key[Add key: D88E42B4 from Apt::Source elasticsearch]: The id should be a full fingerprint (40 characters), see README.
```